### PR TITLE
Fix an error in SegmentationContextHandler.match

### DIFF
--- a/_textable/widgets/TextableUtils.py
+++ b/_textable/widgets/TextableUtils.py
@@ -857,9 +857,9 @@ class SegmentationContextHandler(VersionedSettingsHandlerMixin,
 
         Two contexts match if their encodings are structurally
         equal (==).
-
         """
-        return 2 if context.encoded == args else 0
+        assert len(args) == 1 and isinstance(args[0], Segmentation)
+        return 2 if context.encoded == self.encode(*args) else 0
 
 
 from Orange.widgets import widget


### PR DESCRIPTION
Compare with the encoded segmentation