### PR TITLE
SegmentationListContextHandler: Fix settings_(to|from)_widget

### DIFF
--- a/_textable/widgets/TextableUtils.py
+++ b/_textable/widgets/TextableUtils.py
@@ -814,7 +814,7 @@ class SegmentationListContextHandler(VersionedSettingsHandlerMixin,
             raise ValueError
         return [seq1.index(el) for el in seq2]
 
-    def settings_to_widget(self, widget):
+    def settings_to_widget(self, widget, *args, **kwargs):
         """
         Restore the saved `context` to `widget`.
         """
@@ -847,7 +847,7 @@ class SegmentationListContextHandler(VersionedSettingsHandlerMixin,
             # Restore the stored order in the widget.
             setattr(widget, self.inputListFieldName, permuted)
 
-    def settings_from_widget(self, widget):
+    def settings_from_widget(self, widget, *args, **kwargs):
         """
         Get the settings from a widget.
         """


### PR DESCRIPTION
Orange3 3.21.0 requires that settings_to_widget, and settings_from_widget take arbitrary positional arguments.
A `TypeError: settings_from_widget() takes 2 positional arguments but 4 were given` is raised otherwise.