### PR TITLE
Replace PyQt4 imports with PyQt5

### DIFF
--- a/_textable/widgets/OWTextableCategory.py
+++ b/_textable/widgets/OWTextableCategory.py
@@ -430,7 +430,7 @@ class OWTextableCategory(OWTextableBaseWidget):
 if __name__ == '__main__':
     import sys
     import re
-    from PyQt4.QtGui import  QApplication
+    from PyQt5.QtWidgets import QApplication
     from LTTL.Input import Input
     from LTTL import Segmenter as segmenter
 

--- a/_textable/widgets/OWTextableContext.py
+++ b/_textable/widgets/OWTextableContext.py
@@ -569,7 +569,7 @@ class OWTextableContext(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys, re
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     import LTTL.Segmenter as Segmenter
     from LTTL.Input import Input
 

--- a/_textable/widgets/OWTextableConvert.py
+++ b/_textable/widgets/OWTextableConvert.py
@@ -24,7 +24,7 @@ import os
 import codecs
 import re
 
-from PyQt4.QtGui import QMessageBox, QApplication, QFileDialog
+from PyQt5.QtWidgets import QMessageBox, QApplication, QFileDialog
 import Orange.data
 from Orange.widgets import widget, gui, settings
 

--- a/_textable/widgets/OWTextableCooccurrence.py
+++ b/_textable/widgets/OWTextableCooccurrence.py
@@ -594,7 +594,7 @@ class OWTextableCooccurrence(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     import LTTL.Segmenter as Segmenter
     from LTTL.Input import Input
 

--- a/_textable/widgets/OWTextableCount.py
+++ b/_textable/widgets/OWTextableCount.py
@@ -618,7 +618,7 @@ class OWTextableCount(OWTextableBaseWidget):
 if __name__ == '__main__':
     import sys
 
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     import LTTL.Segmenter as Segmenter
     from LTTL.Input import Input
 

--- a/_textable/widgets/OWTextableDisplay.py
+++ b/_textable/widgets/OWTextableDisplay.py
@@ -25,8 +25,8 @@ import os
 import codecs
 import re
 
-from PyQt4.QtGui import QTextBrowser, QFileDialog, QMessageBox, QApplication
-from PyQt4.QtCore import QUrl
+from PyQt5.QtWidgets import QTextBrowser, QFileDialog, QMessageBox, QApplication
+from PyQt5.QtCore import QUrl
 
 from LTTL.Segmentation import Segmentation
 from LTTL.Input import Input

--- a/_textable/widgets/OWTextableExtractXML.py
+++ b/_textable/widgets/OWTextableExtractXML.py
@@ -22,7 +22,7 @@ __version__ = '0.15.7'
 
 import re
 
-from PyQt4.QtGui import QFont
+from PyQt5.QtGui import QFont
 
 import LTTL.Segmenter as Segmenter
 from LTTL.Segmentation import Segmentation
@@ -698,7 +698,7 @@ class OWTextableExtractXML(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
 
     appl = QApplication(sys.argv)
     ow = OWTextableExtractXML()

--- a/_textable/widgets/OWTextableInterchange.py
+++ b/_textable/widgets/OWTextableInterchange.py
@@ -343,7 +343,7 @@ class OWTextableInterchange(OWTextableBaseWidget):
 
 if __name__ == "__main__":
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     appl = QApplication(sys.argv)
     ow = OWTextableInterchange()
     ow.show()

--- a/_textable/widgets/OWTextableIntersect.py
+++ b/_textable/widgets/OWTextableIntersect.py
@@ -476,7 +476,7 @@ if __name__ == '__main__':
     import sys
     import re
 
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     from LTTL.Input import Input
 
     appl = QApplication(sys.argv)

--- a/_textable/widgets/OWTextableLength.py
+++ b/_textable/widgets/OWTextableLength.py
@@ -496,7 +496,7 @@ class OWTextableLength(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     import LTTL.Segmenter as Segmenter
     from LTTL.Input import Input
 

--- a/_textable/widgets/OWTextableMerge.py
+++ b/_textable/widgets/OWTextableMerge.py
@@ -282,7 +282,7 @@ class OWTextableMerge(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     from LTTL.Input import Input
 
     appl = QApplication(sys.argv)

--- a/_textable/widgets/OWTextableMessage.py
+++ b/_textable/widgets/OWTextableMessage.py
@@ -117,7 +117,7 @@ class OWTextableMessage(OWTextableBaseWidget):
 
 if __name__ == "__main__":
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     appl = QApplication(sys.argv)
     ow = OWTextableMessage()
     ow.show()

--- a/_textable/widgets/OWTextablePreprocess.py
+++ b/_textable/widgets/OWTextablePreprocess.py
@@ -221,7 +221,7 @@ class OWTextablePreprocess(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     appl = QApplication(sys.argv)
     ow = OWTextablePreprocess()
     ow.show()

--- a/_textable/widgets/OWTextableRecode.py
+++ b/_textable/widgets/OWTextableRecode.py
@@ -22,8 +22,8 @@ __version__ = '0.13.7'
 
 import os, re, codecs, json
 
-from PyQt4.QtGui import QFont
-from PyQt4.QtGui import QFileDialog, QMessageBox
+from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
 
 import LTTL.Segmenter as Segmenter
 from LTTL.Segmentation import Segmentation
@@ -796,7 +796,7 @@ class OWTextableRecode(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     appl = QApplication(sys.argv)
     ow = OWTextableRecode()
     ow.show()

--- a/_textable/widgets/OWTextableSegment.py
+++ b/_textable/widgets/OWTextableSegment.py
@@ -22,8 +22,8 @@ __version__ = '0.21.8'
 
 import os, re, codecs, json
 
-from PyQt4.QtGui import QFont
-from PyQt4.QtGui import QFileDialog, QMessageBox
+from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
 import LTTL.Segmenter as Segmenter
 from LTTL.Segmentation import Segmentation
 
@@ -990,7 +990,7 @@ class OWTextableSegment(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     from LTTL.Input import Input
 
     appl = QApplication(sys.argv)

--- a/_textable/widgets/OWTextableSelect.py
+++ b/_textable/widgets/OWTextableSelect.py
@@ -962,7 +962,7 @@ class OWTextableSelect(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     appl = QApplication(sys.argv)
     ow = OWTextableSelect()
     ow.show()

--- a/_textable/widgets/OWTextableTextField.py
+++ b/_textable/widgets/OWTextableTextField.py
@@ -25,7 +25,7 @@ from unicodedata import normalize
 from LTTL.Segmentation import Segmentation
 from LTTL.Input import Input
 
-from PyQt4.QtGui import QPlainTextEdit
+from PyQt5.QtWidgets import QPlainTextEdit
 
 from .TextableUtils import (
     OWTextableBaseWidget, VersionedSettingsHandler,
@@ -155,7 +155,7 @@ class OWTextableTextField(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import  QApplication
+    from PyQt5.QtWidgets import  QApplication
     appl = QApplication(sys.argv)
     ow = OWTextableTextField()
     ow.show()

--- a/_textable/widgets/OWTextableTextFiles.py
+++ b/_textable/widgets/OWTextableTextFiles.py
@@ -27,9 +27,9 @@ import re
 import json
 from unicodedata import normalize
 
-from PyQt4.QtCore import QTimer
-from PyQt4.QtGui import QFileDialog, QMessageBox
-from PyQt4.QtGui import QFont
+from PyQt5.QtCore import QTimer
+from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
 
 from chardet.universaldetector import UniversalDetector
 
@@ -942,7 +942,7 @@ class OWTextableTextFiles(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     appl = QApplication(sys.argv)
     ow = OWTextableTextFiles()
     ow.show()

--- a/_textable/widgets/OWTextableTreetagger.py
+++ b/_textable/widgets/OWTextableTreetagger.py
@@ -28,7 +28,7 @@ from xml.sax.saxutils import quoteattr
 
 from Orange.widgets import gui, settings
 
-from PyQt4.QtGui import QFileDialog, QMessageBox
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
 
 from LTTL.Segmentation import Segmentation
 from LTTL.Input import Input
@@ -466,7 +466,7 @@ class Treetagger(OWTextableBaseWidget):
 
 if __name__ == "__main__":
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
 
     myApplication = QApplication(sys.argv)
     myWidget = Treetagger()

--- a/_textable/widgets/OWTextableURLs.py
+++ b/_textable/widgets/OWTextableURLs.py
@@ -28,9 +28,9 @@ import http
 from unicodedata import normalize
 from urllib.request import urlopen
 
-from PyQt4.QtCore import QTimer
-from PyQt4.QtGui import QFont
-from PyQt4.QtGui import QMessageBox, QFileDialog
+from PyQt5.QtCore import QTimer
+from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import QMessageBox, QFileDialog
 
 import chardet
 
@@ -863,7 +863,7 @@ class OWTextableURLs(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys
-    from PyQt4.QtGui import QApplication
+    from PyQt5.QtWidgets import QApplication
     appl = QApplication(sys.argv)
     ow = OWTextableURLs()
     ow.show()

--- a/_textable/widgets/OWTextableVariety.py
+++ b/_textable/widgets/OWTextableVariety.py
@@ -667,7 +667,7 @@ class OWTextableVariety(OWTextableBaseWidget):
 
 if __name__ == '__main__':
     import sys, re
-    from PyQt4.QtGui import  QApplication
+    from PyQt5.QtWidgets import QApplication
     import LTTL.Segmenter as Segmenter
     from LTTL.Input import Input
 

--- a/_textable/widgets/TextableUtils.py
+++ b/_textable/widgets/TextableUtils.py
@@ -906,8 +906,8 @@ class SegmentationContextHandler(VersionedSettingsHandlerMixin,
 
 
 from Orange.widgets import widget
-from PyQt4.QtCore import QTimer, QEventLoop
-from PyQt4.QtGui import QSizePolicy, QApplication
+from PyQt5.QtCore import QTimer, QEventLoop
+from PyQt5.QtWidgets import QSizePolicy, QApplication
 
 
 class OWTextableBaseWidget(widget.OWWidget):


### PR DESCRIPTION
Orange3 no longer supports PyQt4. It has required PyQt5 for quite some time but inserted a backport stub module under PyQt4 at runtime to ensure add-ons continue to work. However this will stop working in the future.