### PR TITLE
Consistently use signal_id in send calls

### DIFF
--- a/_textable/widgets/OWTextableExtractXML.py
+++ b/_textable/widgets/OWTextableExtractXML.py
@@ -482,7 +482,7 @@ class OWTextableExtractXML(OWTextableBaseWidget):
                     u'Please enter an annotation key for element import.',
                     'warning'
                 )
-                self.send('Extracted data', None)
+                self.send('Extracted data', None, self)
                 return
         else:
             importElementAs = None

--- a/_textable/widgets/OWTextableInterchange.py
+++ b/_textable/widgets/OWTextableInterchange.py
@@ -234,9 +234,9 @@ class OWTextableInterchange(OWTextableBaseWidget):
             new_segmentation = Segmentation(new_segments, self.captionTitle)
             msg_seg = u'%i segment@p' % len(new_segmentation)
             msg_seg = pluralize(msg_seg, len(new_segmentation))
-            self.send('Textable segmentation', new_segmentation)
+            self.send('Textable segmentation', new_segmentation, self)
         else:
-             self.send('Textable segmentation', None)
+             self.send('Textable segmentation', None, self)
 
         # Convert segmentation to corpus...
         if self.segmentation:


### PR DESCRIPTION
Since orange-canvas-core v0.1.19 sending multiple values on the same output channel via different ids is no longer supported and raises a runtime error e.g.
```
Traceback (most recent call last):
  File "/Users/aleserjavec/Documents/workspace/orange3-textable/_textable/widgets/OWTextableInterchange.py", line 239, in sendData
    self.send('Textable segmentation', None)
  File "/Users/aleserjavec/Documents/workspace/orange-widget-base/orangewidget/utils/signals.py", line 285, in send
    self.signalManager.send(self, signalName, value, id)
  File "/Users/aleserjavec/Documents/workspace/orange-widget-base/orangewidget/workflow/widgetsscheme.py", line 736, in send
    super().send(node, channel, value, signal_id)
  File "/Users/aleserjavec/Documents/workspace/orange-canvas/orangecanvas/scheme/signalmanager.py", line 493, in send
    "Sending multiple values on the same output channel via "
RuntimeError: Sending multiple values on the same output channel via different ids is no longer supported.
```

Fix this by consistently using the same id parameter.
