### PR TITLE
Update OWTextableTextFiles.py

### DIFF
--- a/_textable/widgets/OWTextableTextFiles.py
+++ b/_textable/widgets/OWTextableTextFiles.py
@@ -559,7 +559,7 @@ class OWTextableTextFiles(OWTextableBaseWidget):
                     encoding = detector.result['encoding']
                 fh = open(
                     filePath,
-                    mode='rU',
+                    mode='r',
                     encoding=encoding,
                 )
                 try:


### PR DESCRIPTION
reading with the rU argument is deprecated and prevents the widget from running, now it's the standard way to read.
(https://stackoverflow.com/questions/56791545/what-is-the-non-deprecated-version-of-open-u-mode)